### PR TITLE
Support dedicated errors channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Post [GitHub Action](https://github.com/features/actions) deploy workflow progre
 
 - Posts summary message at beginning of the deploy workflow, surfacing commit message and author
 - Maps GitHub commit author to Slack user by full name, mentioning them in the summary message
-- Threads intermediate stage completions, sending unexpected failures back to the channel
+- Threads intermediate stage completions, broadcasting unexpected errors back to the primary channel by default
 - Updates summary message duration at conclusion of the workflow
 - Supports `pull_request`, `push`, `release`, `schedule`, and `workflow_dispatch` [event types](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows)
 
@@ -87,16 +87,25 @@ jobs:
 1. As your workflow progresses, use this action with the `thread_ts` input to post threaded replies.
 1. Denote the last step with the `conclusion` input to update the initial message's status.
 
-## Environment Variables
+### Error Handling
 
-Both environment variables are _required_.
+There are two error handling "modes" (when a job has failed or been cancelled):
 
-| variable                 | description                |
-| ------------------------ | -------------------------- |
-| `SLACK_DEPLOY_BOT_TOKEN` | Slack Bot User OAuth Token |
-| `SLACK_DEPLOY_CHANNEL`   | Slack Channel ID           |
+1. With the single required `SLACK_DEPLOY_CHANNEL` configured, unsuccessful threaded replies will be broadcasted back to this channel.
 
-## Inputs
+1. When `SLACK_DEPLOY_CHANNEL_ERRORS` is _also_ configured, unsuccessful jobs will additionally notify this configured errors channel.
+
+   In this mode, intermediate stage completions will still be threaded in `SLACK_DEPLOY_CHANNEL`, but unsuccessful messages will no longer be sent back to the channel. Therefore, `SLACK_DEPLOY_CHANNEL` effectively serves as a deploy event stream where each deploy is represented by a single channel message.
+
+### Environment Variables
+
+| variable                      | description                             |
+| ----------------------------- | --------------------------------------- |
+| `SLACK_DEPLOY_BOT_TOKEN`      | **Required** Slack Bot User OAuth Token |
+| `SLACK_DEPLOY_CHANNEL`        | **Required** Primary Slack Channel ID   |
+| `SLACK_DEPLOY_CHANNEL_ERRORS` | (Optional) Error Slack Channel ID       |
+
+### Inputs
 
 | input          | description                                                                                                                                                              |
 | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -105,7 +114,7 @@ Both environment variables are _required_.
 | `github_token` | Repository `GITHUB_TOKEN` or personal access token secret; defaults to [`github.token`](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context) |
 | `status`       | The current status of the job; defaults to [`job.status`](https://docs.github.com/en/actions/learn-github-actions/contexts#job-context)                                  |
 
-## Outputs
+### Outputs
 
 | output | description                |
 | ------ | -------------------------- |

--- a/dist/index.js
+++ b/dist/index.js
@@ -59374,7 +59374,7 @@ var EnvironmentVariable;
 (function (EnvironmentVariable) {
     EnvironmentVariable["SlackBotToken"] = "SLACK_DEPLOY_BOT_TOKEN";
     EnvironmentVariable["SlackChannelPrimary"] = "SLACK_DEPLOY_CHANNEL";
-    EnvironmentVariable["SlackChannelUnsuccessful"] = "SLACK_DEPLOY_CHANNEL_UNSUCCESSFUL";
+    EnvironmentVariable["SlackChannelErrors"] = "SLACK_DEPLOY_CHANNEL_ERRORS";
 })(EnvironmentVariable || (exports.EnvironmentVariable = EnvironmentVariable = {}));
 /**
  * Get the value of an environment variable.
@@ -59445,11 +59445,11 @@ function run() {
 function createSlackClient() {
     const token = (0, input_1.getRequiredEnv)(input_1.EnvironmentVariable.SlackBotToken);
     const channelPrimary = (0, input_1.getRequiredEnv)(input_1.EnvironmentVariable.SlackChannelPrimary);
-    const channelUnsuccessful = (0, input_1.getEnv)(input_1.EnvironmentVariable.SlackChannelUnsuccessful);
+    const channelUnsuccessful = (0, input_1.getEnv)(input_1.EnvironmentVariable.SlackChannelErrors);
     return new SlackClient_1.SlackClient({
         token,
         channelPrimary,
-        channelUnsuccessful
+        channelErrors: channelUnsuccessful
     });
 }
 function createOctokitClient() {
@@ -59554,9 +59554,9 @@ const core_1 = __nccwpck_require__(42186);
 const web_api_1 = __nccwpck_require__(60431);
 const errors_1 = __nccwpck_require__(70035);
 class SlackClient {
-    constructor({ token, channelPrimary, channelUnsuccessful }) {
+    constructor({ token, channelPrimary, channelErrors }) {
         this.channelPrimary = channelPrimary;
-        this.channelUnsuccessful = channelUnsuccessful !== null && channelUnsuccessful !== void 0 ? channelUnsuccessful : null;
+        this.channelErrors = channelErrors !== null && channelErrors !== void 0 ? channelErrors : null;
         this.web = new web_api_1.WebClient(token, {
             logLevel: (0, core_1.isDebug)() ? web_api_1.LogLevel.DEBUG : web_api_1.LogLevel.INFO
         });
@@ -59606,14 +59606,14 @@ class SlackClient {
                 // always post successful messages in primary channel thread
                 yield this.web.chat.postMessage(Object.assign(Object.assign({}, options), { channel: this.channelPrimary, thread_ts }));
             }
-            else if (this.channelUnsuccessful) {
-                // post to unsuccessful channel
-                yield this.web.chat.postMessage(Object.assign(Object.assign({}, options), { channel: this.channelUnsuccessful }));
+            else if (this.channelErrors) {
+                // post to error channel
+                yield this.web.chat.postMessage(Object.assign(Object.assign({}, options), { channel: this.channelErrors }));
                 // and primary channel thread
                 yield this.web.chat.postMessage(Object.assign(Object.assign({}, options), { channel: this.channelPrimary, thread_ts }));
             }
             else {
-                // broadcast unsuccessful message to primary channel
+                // broadcast error message to primary channel
                 yield this.web.chat.postMessage(Object.assign(Object.assign({}, options), { channel: this.channelPrimary, thread_ts, reply_broadcast: true }));
             }
         });

--- a/src/__tests__/postMessage.test.ts
+++ b/src/__tests__/postMessage.test.ts
@@ -24,6 +24,7 @@ describe('postMessage', () => {
 
     slack = {
       postMessage: jest.fn(async () => 'TS'),
+      postThreadedMessage: jest.fn(async () => 'TS'),
       updateMessage: jest.fn(async () => undefined)
     } as unknown as SlackClient
 
@@ -336,9 +337,9 @@ describe('postMessage', () => {
         })
       })
 
-      it('should post slack message', () => {
-        expect(slack.postMessage).toHaveBeenCalledTimes(1)
-        expect(slack.postMessage).toHaveBeenCalledWith({
+      it('should post threaded slack message', () => {
+        expect(slack.postThreadedMessage).toHaveBeenCalledTimes(1)
+        expect(slack.postThreadedMessage).toHaveBeenCalledWith({
           icon_url: 'github.com/namoscato',
           username: 'namoscato (via GitHub)',
           unfurl_links: false,
@@ -366,9 +367,13 @@ describe('postMessage', () => {
               ]
             }
           ],
-          reply_broadcast: false,
+          successful: true,
           thread_ts: '1662768000' // 2022-09-10T00:00:00.000Z
         })
+      })
+
+      it('should not post summary message', () => {
+        expect(slack.postMessage).not.toHaveBeenCalled()
       })
 
       it('should not update summary message', () => {
@@ -388,7 +393,7 @@ describe('postMessage', () => {
       })
 
       it('should post slack message', () => {
-        expect(slack.postMessage).toHaveBeenCalledWith(
+        expect(slack.postThreadedMessage).toHaveBeenCalledWith(
           expect.objectContaining({
             text: 'Cancelled JOB 2',
             blocks: expect.arrayContaining([
@@ -400,7 +405,7 @@ describe('postMessage', () => {
                 }
               }
             ]),
-            reply_broadcast: true
+            successful: false
           })
         )
       })
@@ -456,10 +461,10 @@ describe('postMessage', () => {
       })
 
       it('should post slack message', () => {
-        expect(slack.postMessage).toHaveBeenCalledWith(
+        expect(slack.postThreadedMessage).toHaveBeenCalledWith(
           expect.objectContaining({
             text: 'Finished JOB 2',
-            reply_broadcast: false
+            successful: true
           })
         )
       })
@@ -506,10 +511,10 @@ describe('postMessage', () => {
       })
 
       it('should post slack message', () => {
-        expect(slack.postMessage).toHaveBeenCalledWith(
+        expect(slack.postThreadedMessage).toHaveBeenCalledWith(
           expect.objectContaining({
             text: 'Failed JOB 2',
-            reply_broadcast: true
+            successful: false
           })
         )
       })
@@ -558,7 +563,7 @@ describe('postMessage', () => {
       })
 
       it('should post slack message', () => {
-        expect(slack.postMessage).toHaveBeenCalledWith(
+        expect(slack.postThreadedMessage).toHaveBeenCalledWith(
           expect.objectContaining({
             text: 'Finished JOB 2',
             blocks: expect.arrayContaining([
@@ -592,7 +597,7 @@ describe('postMessage', () => {
       })
 
       it('should post slack message', () => {
-        expect(slack.postMessage).toHaveBeenCalledWith(
+        expect(slack.postThreadedMessage).toHaveBeenCalledWith(
           expect.objectContaining({
             text: 'Finished JOB 2',
             blocks: expect.arrayContaining([

--- a/src/github/getSummaryMessage.ts
+++ b/src/github/getSummaryMessage.ts
@@ -1,11 +1,11 @@
 import * as github from '@actions/github'
 import {intervalToDuration} from 'date-fns'
 import {bold, emoji, link} from '../slack/mrkdwn'
-import {Link, MessageAuthor} from '../slack/types'
+import {Link, MessageArguments, MessageAuthor} from '../slack/types'
 import {dateFromTs} from '../slack/utils'
 import {getContextBlock} from './getContextBlock'
 import {createMessage, emojiFromStatus} from './message'
-import {JobStatus, Message, OctokitClient, Text} from './types'
+import {JobStatus, OctokitClient, Text} from './types'
 import {
   SupportedContext,
   assertUnsupportedEvent,
@@ -35,7 +35,7 @@ export async function getSummaryMessage({
   octokit,
   options,
   author
-}: Dependencies): Promise<Message> {
+}: Dependencies): Promise<MessageArguments> {
   const text = await getText(octokit, options?.status ?? null, author)
 
   const duration = options

--- a/src/github/getSummaryMessage.ts
+++ b/src/github/getSummaryMessage.ts
@@ -1,7 +1,7 @@
 import * as github from '@actions/github'
 import {intervalToDuration} from 'date-fns'
 import {bold, emoji, link} from '../slack/mrkdwn'
-import {Link, MessageArguments, MessageAuthor} from '../slack/types'
+import {Link, MessageAuthor, PostMessageArguments} from '../slack/types'
 import {dateFromTs} from '../slack/utils'
 import {getContextBlock} from './getContextBlock'
 import {createMessage, emojiFromStatus} from './message'
@@ -35,7 +35,7 @@ export async function getSummaryMessage({
   octokit,
   options,
   author
-}: Dependencies): Promise<MessageArguments> {
+}: Dependencies): Promise<PostMessageArguments> {
   const text = await getText(octokit, options?.status ?? null, author)
 
   const duration = options

--- a/src/github/message.ts
+++ b/src/github/message.ts
@@ -1,7 +1,7 @@
 import {ContextBlock} from '@slack/web-api'
 import {emoji} from '../slack/mrkdwn'
-import {MessageAuthor} from '../slack/types'
-import {JobStatus, Message, Text} from './types'
+import {MessageArguments, MessageAuthor} from '../slack/types'
+import {JobStatus, Text} from './types'
 
 interface Dependencies {
   text: Text
@@ -13,7 +13,7 @@ export function createMessage({
   text,
   contextBlock,
   author
-}: Dependencies): Message {
+}: Dependencies): MessageArguments {
   return {
     icon_url: author?.icon_url,
     username: author?.username ? `${author.username} (via GitHub)` : undefined,

--- a/src/github/message.ts
+++ b/src/github/message.ts
@@ -1,6 +1,6 @@
 import {ContextBlock} from '@slack/web-api'
 import {emoji} from '../slack/mrkdwn'
-import {MessageArguments, MessageAuthor} from '../slack/types'
+import {MessageAuthor, PostMessageArguments} from '../slack/types'
 import {JobStatus, Text} from './types'
 
 interface Dependencies {
@@ -13,7 +13,7 @@ export function createMessage({
   text,
   contextBlock,
   author
-}: Dependencies): MessageArguments {
+}: Dependencies): PostMessageArguments {
   return {
     icon_url: author?.icon_url,
     username: author?.username ? `${author.username} (via GitHub)` : undefined,

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -1,6 +1,6 @@
 import type {GitHub} from '@actions/github/lib/utils'
 import type {Endpoints} from '@octokit/types'
-import {MessageArguments} from '../slack/types'
+import {PostMessageArguments} from '../slack/types'
 
 export type OctokitClient = InstanceType<typeof GitHub>
 
@@ -9,7 +9,7 @@ export interface Text {
   mrkdwn: string
 }
 
-export interface StageMessage extends MessageArguments {
+export interface StageMessage extends PostMessageArguments {
   successful: boolean
 }
 

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -1,6 +1,6 @@
 import type {GitHub} from '@actions/github/lib/utils'
 import type {Endpoints} from '@octokit/types'
-import type {KnownBlock} from '@slack/web-api'
+import {MessageArguments} from '../slack/types'
 
 export type OctokitClient = InstanceType<typeof GitHub>
 
@@ -9,15 +9,7 @@ export interface Text {
   mrkdwn: string
 }
 
-export interface Message {
-  icon_url: string | undefined
-  username: string | undefined
-  unfurl_links: boolean
-  text: string
-  blocks: KnownBlock[]
-}
-
-export interface StageMessage extends Message {
+export interface StageMessage extends MessageArguments {
   successful: boolean
 }
 

--- a/src/input.ts
+++ b/src/input.ts
@@ -1,7 +1,7 @@
 export enum EnvironmentVariable {
   SlackBotToken = 'SLACK_DEPLOY_BOT_TOKEN',
   SlackChannelPrimary = 'SLACK_DEPLOY_CHANNEL',
-  SlackChannelUnsuccessful = 'SLACK_DEPLOY_CHANNEL_UNSUCCESSFUL'
+  SlackChannelErrors = 'SLACK_DEPLOY_CHANNEL_ERRORS'
 }
 
 /**

--- a/src/input.ts
+++ b/src/input.ts
@@ -1,15 +1,23 @@
 export enum EnvironmentVariable {
   SlackBotToken = 'SLACK_DEPLOY_BOT_TOKEN',
-  SlackChannel = 'SLACK_DEPLOY_CHANNEL'
+  SlackChannelPrimary = 'SLACK_DEPLOY_CHANNEL',
+  SlackChannelUnsuccessful = 'SLACK_DEPLOY_CHANNEL_UNSUCCESSFUL'
+}
+
+/**
+ * Get the value of an environment variable.
+ *
+ * The value is trimmed of whitespace.
+ */
+export function getEnv(name: EnvironmentVariable): string | undefined {
+  return String(process.env[name] ?? '').trim() || undefined
 }
 
 /**
  * Get the value of a required environment variable.
- *
- * The value is trimmed of whitespace.
  */
-export function getEnv(name: EnvironmentVariable): string {
-  const env = String(process.env[name] ?? '').trim()
+export function getRequiredEnv(name: EnvironmentVariable): string {
+  const env = getEnv(name)
 
   if (!env) {
     throw new Error(`${name} environment variable required`)

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,14 +31,12 @@ async function run(): Promise<void> {
 function createSlackClient(): SlackClient {
   const token = getRequiredEnv(EnvironmentVariable.SlackBotToken)
   const channelPrimary = getRequiredEnv(EnvironmentVariable.SlackChannelPrimary)
-  const channelUnsuccessful = getEnv(
-    EnvironmentVariable.SlackChannelUnsuccessful
-  )
+  const channelUnsuccessful = getEnv(EnvironmentVariable.SlackChannelErrors)
 
   return new SlackClient({
     token,
     channelPrimary,
-    channelUnsuccessful
+    channelErrors: channelUnsuccessful
   })
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,9 +2,11 @@ import {error, getInput, isDebug, setFailed, setOutput} from '@actions/core'
 import {getOctokit} from '@actions/github'
 import {getMessageAuthor} from './getMessageAuthor'
 import {OctokitClient} from './github/types'
-import {EnvironmentVariable, getEnv} from './input'
+import {EnvironmentVariable, getEnv, getRequiredEnv} from './input'
 import {postMessage} from './postMessage'
 import {SlackClient} from './slack/SlackClient'
+
+run()
 
 async function run(): Promise<void> {
   try {
@@ -27,10 +29,17 @@ async function run(): Promise<void> {
 }
 
 function createSlackClient(): SlackClient {
-  const token = getEnv(EnvironmentVariable.SlackBotToken)
-  const channel = getEnv(EnvironmentVariable.SlackChannel)
+  const token = getRequiredEnv(EnvironmentVariable.SlackBotToken)
+  const channelPrimary = getRequiredEnv(EnvironmentVariable.SlackChannelPrimary)
+  const channelUnsuccessful = getEnv(
+    EnvironmentVariable.SlackChannelUnsuccessful
+  )
 
-  return new SlackClient({token, channel})
+  return new SlackClient({
+    token,
+    channelPrimary,
+    channelUnsuccessful
+  })
 }
 
 function createOctokitClient(): OctokitClient {
@@ -38,5 +47,3 @@ function createOctokitClient(): OctokitClient {
 
   return getOctokit(token)
 }
-
-run()

--- a/src/postMessage.ts
+++ b/src/postMessage.ts
@@ -34,7 +34,7 @@ export async function postMessage({
 
   const status = getInput('status', {required: true})
   const now = new Date()
-  const {successful, ...stageMessage} = await getStageMessage({
+  const stageMessage = await getStageMessage({
     octokit,
     status,
     now,
@@ -42,9 +42,8 @@ export async function postMessage({
   })
 
   info(`Posting stage message in thread: ${threadTs}`)
-  await slack.postMessage({
+  await slack.postThreadedMessage({
     ...stageMessage,
-    reply_broadcast: !successful,
     thread_ts: threadTs
   })
 

--- a/src/slack/SlackClient.ts
+++ b/src/slack/SlackClient.ts
@@ -3,7 +3,7 @@ import {LogLevel, WebClient, WebClientEvent} from '@slack/web-api'
 import {isMissingScopeError} from './errors'
 import type {
   Member,
-  MessageArguments,
+  PostMessageArguments,
   PostThreadedMessageArguments,
   UpdateMessageArguments
 } from './types'
@@ -60,7 +60,7 @@ export class SlackClient {
   /**
    * @returns message timestamp ID
    */
-  async postMessage(options: MessageArguments): Promise<string> {
+  async postMessage(options: PostMessageArguments): Promise<string> {
     const {ts} = await this.web.chat.postMessage({
       ...options,
       channel: this.channelPrimary

--- a/src/slack/SlackClient.ts
+++ b/src/slack/SlackClient.ts
@@ -11,17 +11,17 @@ import type {
 interface Dependencies {
   token: string
   channelPrimary: string
-  channelUnsuccessful: string | undefined
+  channelErrors: string | undefined
 }
 
 export class SlackClient {
   private readonly web: WebClient
   private readonly channelPrimary: string
-  private readonly channelUnsuccessful: string | null
+  private readonly channelErrors: string | null
 
-  constructor({token, channelPrimary, channelUnsuccessful}: Dependencies) {
+  constructor({token, channelPrimary, channelErrors}: Dependencies) {
     this.channelPrimary = channelPrimary
-    this.channelUnsuccessful = channelUnsuccessful ?? null
+    this.channelErrors = channelErrors ?? null
 
     this.web = new WebClient(token, {
       logLevel: isDebug() ? LogLevel.DEBUG : LogLevel.INFO
@@ -85,11 +85,11 @@ export class SlackClient {
         channel: this.channelPrimary,
         thread_ts
       })
-    } else if (this.channelUnsuccessful) {
-      // post to unsuccessful channel
+    } else if (this.channelErrors) {
+      // post to error channel
       await this.web.chat.postMessage({
         ...options,
-        channel: this.channelUnsuccessful
+        channel: this.channelErrors
       })
 
       // and primary channel thread
@@ -99,7 +99,7 @@ export class SlackClient {
         thread_ts
       })
     } else {
-      // broadcast unsuccessful message to primary channel
+      // broadcast error message to primary channel
       await this.web.chat.postMessage({
         ...options,
         channel: this.channelPrimary,

--- a/src/slack/__tests__/SlackClient.test.ts
+++ b/src/slack/__tests__/SlackClient.test.ts
@@ -24,7 +24,8 @@ jest.mock('@slack/web-api', () => ({
 describe('SlackClient', () => {
   const client = new SlackClient({
     token: 'TOKEN',
-    channel: 'CHANNEL'
+    channelPrimary: 'CHANNEL',
+    channelUnsuccessful: undefined
   })
 
   describe('getRealUsers', () => {

--- a/src/slack/types.ts
+++ b/src/slack/types.ts
@@ -31,7 +31,12 @@ export interface Image {
   image_url: string
 }
 
-export type PostMessageArguments = MessageArguments & ReplyInThread
+export interface PostThreadedMessageArguments extends MessageArguments {
+  /** Provide another message's `ts` value to post this message in a thread. */
+  thread_ts: string
+  /** Denotes the stage message status. */
+  successful: boolean
+}
 
 export interface UpdateMessageArguments extends MessageArguments {
   /** Timestamp of the message. */
@@ -39,7 +44,7 @@ export interface UpdateMessageArguments extends MessageArguments {
 }
 
 /** Stricter and compatible with `ChatPostMessageArguments` / `ChatUpdateArguments` */
-interface MessageArguments {
+export interface MessageArguments {
   /** URL to an image to use as the icon for this message */
   icon_url: string | undefined
   /** Set your bot's username */
@@ -50,19 +55,4 @@ interface MessageArguments {
   text: string
   /** An array of structured Blocks. */
   blocks: KnownBlock[]
-}
-
-/** Copied from `@slack/web-api` source types */
-type ReplyInThread = WithinThreadReply | BroadcastedThreadReply
-
-interface WithinThreadReply extends Partial<ThreadTS> {
-  reply_broadcast?: false
-}
-
-interface BroadcastedThreadReply extends ThreadTS {
-  reply_broadcast: true
-}
-
-interface ThreadTS {
-  thread_ts: string
 }

--- a/src/slack/types.ts
+++ b/src/slack/types.ts
@@ -31,20 +31,8 @@ export interface Image {
   image_url: string
 }
 
-export interface PostThreadedMessageArguments extends MessageArguments {
-  /** Provide another message's `ts` value to post this message in a thread. */
-  thread_ts: string
-  /** Denotes the stage message status. */
-  successful: boolean
-}
-
-export interface UpdateMessageArguments extends MessageArguments {
-  /** Timestamp of the message. */
-  ts: string
-}
-
 /** Stricter and compatible with `ChatPostMessageArguments` / `ChatUpdateArguments` */
-export interface MessageArguments {
+export interface PostMessageArguments {
   /** URL to an image to use as the icon for this message */
   icon_url: string | undefined
   /** Set your bot's username */
@@ -55,4 +43,16 @@ export interface MessageArguments {
   text: string
   /** An array of structured Blocks. */
   blocks: KnownBlock[]
+}
+
+export interface PostThreadedMessageArguments extends PostMessageArguments {
+  /** Provide another message's `ts` value to post this message in a thread. */
+  thread_ts: string
+  /** Denotes the stage message status. */
+  successful: boolean
+}
+
+export interface UpdateMessageArguments extends PostMessageArguments {
+  /** Timestamp of the message. */
+  ts: string
 }


### PR DESCRIPTION
_See [Reroute successful deploy notifications](https://www.notion.so/fieldguide/Reroute-successful-deploy-notifications-8ad9142318b043148f8f50bc24be129d) for additional context._

## Summary

* Add optional `SLACK_DEPLOY_CHANNEL_ERRORS` environment variable configuration
* Introduce `SlackClient.postThreadedMessage()` that conditionally implements new error handling flow
* Simplify types per the above change, notably removing `ReplyInThread`

## Testing

Tested E2E in a testing repository / channel, i.e.

* primary channel error message is not broadcasted:

   ![Screenshot 2024-07-18 at 10 51 07 PM](https://github.com/user-attachments/assets/eb24d0f4-e616-4c6f-b0ab-46b901495ed0)

* error message is posted to configured errors channel:

   ![Screenshot 2024-07-18 at 10 51 26 PM](https://github.com/user-attachments/assets/5e4fcfad-9c96-4bff-9679-7d013544c469)
