### PR TITLE
[sc-51092] Derive GitHub merge queue author

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Post [GitHub Action](https://github.com/features/actions) deploy workflow progre
 ## Features
 
 - Posts summary message at beginning of the deploy workflow, surfacing commit message and author
-- Maps GitHub commit author to Slack user by full name, mentioning them in the summary message
+- Maps GitHub actor to Slack user by full name, mentioning them in the summary message
 - Threads intermediate stage completions, sending unexpected failures back to the channel
 - Adds summary message reaction to unsuccessful jobs (useful with [Reacji Channeler](https://reacji-channeler.builtbyslack.com/))
 - Updates summary message duration at conclusion of the workflow
@@ -22,7 +22,7 @@ Post [GitHub Action](https://github.com/features/actions) deploy workflow progre
 1. [Create a Slack App](https://api.slack.com/apps) for your workspace
 1. Under **OAuth & Permissions**, add two Bot Token Scopes:
    1. [`chat:write`](https://api.slack.com/scopes/chat:write) to post messages
-   1. [`chat:write.customize`](https://api.slack.com/scopes/chat:write.customize) to customize messages with GitHub commit author
+   1. [`chat:write.customize`](https://api.slack.com/scopes/chat:write.customize) to customize messages with GitHub actor
    1. [`reactions:write`](https://api.slack.com/scopes/reactions:write) to add summary message error reactions
    1. [`users:read`](https://api.slack.com/scopes/users:read) to map GitHub user to Slack user
 1. Install the app to your workspace

--- a/dist/index.js
+++ b/dist/index.js
@@ -58826,19 +58826,19 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getMessageAuthor = void 0;
+exports.getMessageAuthor = exports.GH_MERGE_QUEUE_BOT_USERNAME = void 0;
 const core_1 = __nccwpck_require__(42186);
 const github_1 = __nccwpck_require__(95438);
 const webhook_1 = __nccwpck_require__(50302);
-const GH_MERGE_QUEUE_BOT_USERNAME = 'github-merge-queue[bot]';
+exports.GH_MERGE_QUEUE_BOT_USERNAME = 'github-merge-queue[bot]';
 function getMessageAuthor(octokit, slack) {
     return __awaiter(this, void 0, void 0, function* () {
         (0, core_1.startGroup)('Getting message author');
         const author = yield fetchAuthor(octokit, slack);
         try {
-            if (author && GH_MERGE_QUEUE_BOT_USERNAME === author.username) {
+            if (author && exports.GH_MERGE_QUEUE_BOT_USERNAME === author.username) {
                 (0, core_1.info)('Author is GH Merge Queue Bot User. Fetching actual author via PR info.');
-                return getSenderFromPRMerger(octokit);
+                return yield getSenderFromPRMerger(octokit);
             }
             return author;
         }
@@ -58924,9 +58924,6 @@ function getSenderFromPRMerger(octokit) {
             throw new Error(`Failed to parse PR number from commit message: '${(_b = payload.head_commit) === null || _b === void 0 ? void 0 : _b.message}'.`);
         }
         const prNumber = Number(matches[1]);
-        if (isNaN(prNumber)) {
-            throw new Error(`Matched PR number is not a number: '${prNumber}'.`);
-        }
         if (!payload.repository) {
             throw new Error('WebhookPayload does not include repository information');
         }

--- a/dist/index.js
+++ b/dist/index.js
@@ -58833,6 +58833,7 @@ const webhook_1 = __nccwpck_require__(50302);
 exports.GH_MERGE_QUEUE_BOT_USERNAME = 'github-merge-queue[bot]';
 function getMessageAuthor(octokit, slack) {
     return __awaiter(this, void 0, void 0, function* () {
+        (0, core_1.startGroup)('Getting message author');
         try {
             (0, core_1.info)('Fetching Slack users');
             const slackUsers = yield slack.getRealUsers();

--- a/dist/index.js
+++ b/dist/index.js
@@ -58925,7 +58925,11 @@ function getGitHubPRMergerUser(octokit) {
         if (!mergedBy) {
             throw new Error('PR details does not include `merged_by` details.');
         }
-        return mergedBy;
+        (0, core_1.info)(`Fetching PR Merger GitHub user: ${mergedBy.login}`);
+        const { data } = yield octokit.rest.users.getByUsername({
+            username: mergedBy.login
+        });
+        return data;
     });
 }
 

--- a/src/__tests__/getMessageAuthor.test.ts
+++ b/src/__tests__/getMessageAuthor.test.ts
@@ -33,7 +33,9 @@ describe('getMessageAuthor', () => {
         users: {
           getByUsername: jest.fn(async () => ({
             data: {
-              name: 'Miles Davis'
+              name: 'Miles Davis',
+              login: 'mdavis',
+              avatar_url: 'github.com/mdavis'
             }
           }))
         },
@@ -41,7 +43,6 @@ describe('getMessageAuthor', () => {
           get: jest.fn(async () => ({
             data: {
               merged_by: {
-                name: 'Miles Davis',
                 login: 'mdavis',
                 avatar_url: 'github.com/mdavis'
               }
@@ -226,11 +227,17 @@ describe('getMessageAuthor', () => {
         messageAuthor = await getMessageAuthor(octokit, slack)
       })
 
-      it('fetches GH user info from the PR data', () => {
+      it('fetches the GH user that merged the PR', () => {
         expect(octokit.rest.pulls.get).toHaveBeenCalledWith({
           owner: 'namoscato',
           pull_number: 123,
           repo: 'action-testing'
+        })
+      })
+
+      it('fetches additional GH user info based on `merged_by` PR data', () => {
+        expect(octokit.rest.users.getByUsername).toHaveBeenCalledWith({
+          username: 'mdavis'
         })
       })
 

--- a/src/getMessageAuthor.ts
+++ b/src/getMessageAuthor.ts
@@ -5,12 +5,45 @@ import {senderFromPayload} from './github/webhook'
 import {SlackClient} from './slack/SlackClient'
 import {MemberWithProfile, MessageAuthor} from './slack/types'
 
+const GH_MERGE_QUEUE_BOT_USERNAME = 'github-merge-queue[bot]'
+
 export async function getMessageAuthor(
   octokit: OctokitClient,
   slack: SlackClient
 ): Promise<MessageAuthor | null> {
   startGroup('Getting message author')
 
+  const author = await fetchAuthor(octokit, slack)
+
+  try {
+    if (author && GH_MERGE_QUEUE_BOT_USERNAME === author.username) {
+      info(
+        'Author is GH Merge Queue Bot User. Fetching actual author via PR info.'
+      )
+      return getSenderFromPRMerger(octokit)
+    }
+
+    return author
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    warning(
+      `${message}. Failed to fetch author via PR info, fallback to a GitHub username.`
+    )
+
+    if (isDebug() && err instanceof Error && err.stack) {
+      warning(err.stack)
+    }
+
+    return author
+  } finally {
+    endGroup()
+  }
+}
+
+async function fetchAuthor(
+  octokit: OctokitClient,
+  slack: SlackClient
+): Promise<MessageAuthor | null> {
   try {
     info('Fetching Slack users')
     const slackUsers = await slack.getRealUsers()
@@ -56,8 +89,6 @@ export async function getMessageAuthor(
     }
 
     return authorFromGitHubContext()
-  } finally {
-    endGroup()
   }
 }
 
@@ -86,5 +117,46 @@ function authorFromGitHubContext(): MessageAuthor | null {
   return {
     username: sender.login,
     icon_url: sender.avatar_url
+  }
+}
+
+async function getSenderFromPRMerger(
+  octokit: OctokitClient
+): Promise<MessageAuthor> {
+  const payload = context.payload
+
+  const matches = (payload.head_commit?.message as string).match(/\(#(\d+)\)$/)
+
+  if (!matches) {
+    throw new Error(
+      `Failed to parse PR number from commit message: '${payload.head_commit?.message}'.`
+    )
+  }
+
+  const prNumber = Number(matches[1])
+
+  if (isNaN(prNumber)) {
+    throw new Error(`Matched PR number is not a number: '${prNumber}'.`)
+  }
+
+  if (!payload.repository) {
+    throw new Error('WebhookPayload does not include repository information')
+  }
+
+  const mergedBy = (
+    await octokit.rest.pulls.get({
+      owner: payload.repository.organization,
+      repo: payload.repository.name,
+      pull_number: prNumber
+    })
+  ).data.merged_by
+
+  if (!mergedBy) {
+    throw new Error('PR details does not include `merged_by` details.')
+  }
+
+  return {
+    username: mergedBy.login,
+    icon_url: mergedBy.avatar_url
   }
 }

--- a/src/getMessageAuthor.ts
+++ b/src/getMessageAuthor.ts
@@ -144,5 +144,10 @@ async function getGitHubPRMergerUser(octokit: OctokitClient): Promise<User> {
     throw new Error('PR details does not include `merged_by` details.')
   }
 
-  return mergedBy as User
+  info(`Fetching PR Merger GitHub user: ${mergedBy.login}`)
+  const {data} = await octokit.rest.users.getByUsername({
+    username: mergedBy.login
+  })
+
+  return data
 }

--- a/src/getMessageAuthor.ts
+++ b/src/getMessageAuthor.ts
@@ -5,7 +5,7 @@ import {senderFromPayload} from './github/webhook'
 import {SlackClient} from './slack/SlackClient'
 import {MemberWithProfile, MessageAuthor} from './slack/types'
 
-const GH_MERGE_QUEUE_BOT_USERNAME = 'github-merge-queue[bot]'
+export const GH_MERGE_QUEUE_BOT_USERNAME = 'github-merge-queue[bot]'
 
 export async function getMessageAuthor(
   octokit: OctokitClient,
@@ -20,7 +20,7 @@ export async function getMessageAuthor(
       info(
         'Author is GH Merge Queue Bot User. Fetching actual author via PR info.'
       )
-      return getSenderFromPRMerger(octokit)
+      return await getSenderFromPRMerger(octokit)
     }
 
     return author
@@ -134,10 +134,6 @@ async function getSenderFromPRMerger(
   }
 
   const prNumber = Number(matches[1])
-
-  if (isNaN(prNumber)) {
-    throw new Error(`Matched PR number is not a number: '${prNumber}'.`)
-  }
 
   if (!payload.repository) {
     throw new Error('WebhookPayload does not include repository information')

--- a/src/getMessageAuthor.ts
+++ b/src/getMessageAuthor.ts
@@ -1,4 +1,4 @@
-import {endGroup, info, isDebug, warning} from '@actions/core'
+import {endGroup, info, isDebug, startGroup, warning} from '@actions/core'
 import {context} from '@actions/github'
 import type {Commit} from '@octokit/webhooks-types'
 import {OctokitClient, User} from './github/types'
@@ -13,6 +13,8 @@ export async function getMessageAuthor(
   octokit: OctokitClient,
   slack: SlackClient
 ): Promise<MessageAuthor | null> {
+  startGroup('Getting message author')
+
   try {
     info('Fetching Slack users')
     const slackUsers = await slack.getRealUsers()

--- a/src/github/webhook.ts
+++ b/src/github/webhook.ts
@@ -113,7 +113,11 @@ export function assertUnsupportedEvent(context: never): never {
   throw new UnsupportedEventError(context as GitHubContext)
 }
 
-export function senderFromPayload({sender}: WebhookPayload): User | undefined {
+export type GitHubSender = Pick<User, 'login' | 'avatar_url'>
+
+export function senderFromPayload({
+  sender
+}: WebhookPayload): GitHubSender | undefined {
   if (sender?.login && sender.avatar_url) {
     return sender as User
   }


### PR DESCRIPTION
Updates the `getMessageAuthor` logic to ensure the proper user is @ mentioned when merged via the GH merge queue. This is handled by parsing the PR number from the commit message and looking what user authorized that merge.