### PR TITLE
Scope Slack name mapping to summary message

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -39667,7 +39667,7 @@ function wrappy (fn, cb) {
 
 /***/ }),
 
-/***/ 45021:
+/***/ 50835:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -39683,20 +39683,32 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.GH_MERGE_QUEUE_BOT_USERNAME = void 0;
-exports.getMessageAuthor = getMessageAuthor;
+exports.getMessageAuthorFactory = getMessageAuthorFactory;
 const core_1 = __nccwpck_require__(59999);
 const github_1 = __nccwpck_require__(75380);
 const webhook_1 = __nccwpck_require__(45568);
 exports.GH_MERGE_QUEUE_BOT_USERNAME = 'github-merge-queue[bot]';
-function getMessageAuthor(octokit, slack) {
+function getMessageAuthorFactory(octokit, slack) {
+    return (...args_1) => __awaiter(this, [...args_1], void 0, function* ({ withSlackUserId } = { withSlackUserId: false }) {
+        return getMessageAuthor(octokit, slack, withSlackUserId);
+    });
+}
+function getMessageAuthor(octokit, slack, withSlackUserId) {
     return __awaiter(this, void 0, void 0, function* () {
         (0, core_1.startGroup)('Getting message author');
         const githubSender = yield getGitHubSender(octokit);
         if (!githubSender) {
             (0, core_1.warning)('Unexpected GitHub sender payload.');
+            (0, core_1.endGroup)();
             return null;
         }
         try {
+            if (!withSlackUserId) {
+                return {
+                    username: githubSender.login,
+                    icon_url: githubSender.avatar_url
+                };
+            }
             (0, core_1.info)('Fetching Slack users');
             const slackUsers = yield slack.getRealUsers();
             (0, core_1.info)(`Fetching GitHub user: ${githubSender.login}`);
@@ -39901,10 +39913,11 @@ const types_1 = __nccwpck_require__(83712);
  * Return a progressed stage message, posted via threaded reply.
  */
 function getStageMessage(_a) {
-    return __awaiter(this, arguments, void 0, function* ({ octokit, status, now, author }) {
+    return __awaiter(this, arguments, void 0, function* ({ octokit, status, now, getMessageAuthor }) {
         const text = getText(status);
         const duration = yield computeDuration(octokit, now);
         const contextBlock = (0, getContextBlock_1.getContextBlock)(duration);
+        const author = yield getMessageAuthor();
         return Object.assign(Object.assign({}, (0, message_1.createMessage)({ text, contextBlock, author })), { successful: (0, types_1.isSuccessfulStatus)(status) });
     });
 }
@@ -40013,8 +40026,9 @@ const webhook_1 = __nccwpck_require__(45568);
  * Return the initial summary message.
  */
 function getSummaryMessage(_a) {
-    return __awaiter(this, arguments, void 0, function* ({ octokit, options, author }) {
+    return __awaiter(this, arguments, void 0, function* ({ octokit, options, getMessageAuthor }) {
         var _b;
+        const author = yield getMessageAuthor({ withSlackUserId: true });
         const text = yield getText(octokit, (_b = options === null || options === void 0 ? void 0 : options.status) !== null && _b !== void 0 ? _b : null, author);
         const duration = options
             ? (0, date_fns_1.intervalToDuration)({
@@ -40316,7 +40330,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const core_1 = __nccwpck_require__(59999);
 const github_1 = __nccwpck_require__(75380);
-const getMessageAuthor_1 = __nccwpck_require__(45021);
+const getMessageAuthorFactory_1 = __nccwpck_require__(50835);
 const input_1 = __nccwpck_require__(15229);
 const postMessage_1 = __nccwpck_require__(70352);
 const SlackClient_1 = __nccwpck_require__(84713);
@@ -40326,8 +40340,8 @@ function run() {
         try {
             const octokit = createOctokitClient();
             const slack = createSlackClient();
-            const author = yield (0, getMessageAuthor_1.getMessageAuthor)(octokit, slack);
-            const ts = yield (0, postMessage_1.postMessage)({ octokit, slack, author });
+            const getMessageAuthor = (0, getMessageAuthorFactory_1.getMessageAuthorFactory)(octokit, slack);
+            const ts = yield (0, postMessage_1.postMessage)({ octokit, slack, getMessageAuthor });
             if (ts) {
                 (0, core_1.setOutput)('ts', ts);
             }
@@ -40397,11 +40411,11 @@ const types_1 = __nccwpck_require__(83712);
  * @returns message timestamp ID
  */
 function postMessage(_a) {
-    return __awaiter(this, arguments, void 0, function* ({ octokit, slack, author }) {
+    return __awaiter(this, arguments, void 0, function* ({ octokit, slack, getMessageAuthor }) {
         const threadTs = (0, core_1.getInput)('thread_ts');
         if (!threadTs) {
             (0, core_1.info)('Posting summary message');
-            const message = yield (0, getSummaryMessage_1.getSummaryMessage)({ octokit, author });
+            const message = yield (0, getSummaryMessage_1.getSummaryMessage)({ octokit, getMessageAuthor });
             return slack.postMessage(message);
         }
         const status = (0, core_1.getInput)('status', { required: true });
@@ -40410,7 +40424,7 @@ function postMessage(_a) {
             octokit,
             status,
             now,
-            author
+            getMessageAuthor
         }), { successful } = _b, stageMessage = __rest(_b, ["successful"]);
         (0, core_1.info)(`Posting stage message in thread: ${threadTs}`);
         yield slack.postMessage(Object.assign(Object.assign({}, stageMessage), { reply_broadcast: !successful, thread_ts: threadTs }));
@@ -40421,7 +40435,7 @@ function postMessage(_a) {
             const summaryMessage = yield (0, getSummaryMessage_1.getSummaryMessage)({
                 octokit,
                 options: { status, threadTs, now },
-                author
+                getMessageAuthor
             });
             yield slack.updateMessage(Object.assign(Object.assign({}, summaryMessage), { ts: threadTs }));
         }
@@ -40483,7 +40497,8 @@ class SlackClient {
         this.channel = channel;
         this.errorReaction = errorReaction;
         this.web = new web_api_1.WebClient(token, {
-            logLevel: (0, core_1.isDebug)() ? web_api_1.LogLevel.DEBUG : web_api_1.LogLevel.INFO
+            logLevel: (0, core_1.isDebug)() ? web_api_1.LogLevel.DEBUG : web_api_1.LogLevel.INFO,
+            rejectRateLimitedCalls: true
         });
         this.logRateLimits();
     }
@@ -40562,8 +40577,8 @@ class SlackClient {
      * @see https://slack.dev/node-slack-sdk/web-api#rate-limits
      */
     logRateLimits() {
-        this.web.on(web_api_1.WebClientEvent.RATE_LIMITED, numSeconds => {
-            (0, core_1.warning)(`Slack API call failed due to rate limiting. Retrying in ${numSeconds} seconds.`);
+        this.web.on(web_api_1.WebClientEvent.RATE_LIMITED, () => {
+            (0, core_1.warning)('Slack API call failed due to rate limiting.');
         });
     }
 }

--- a/src/__tests__/getMessageAuthorFactory.test.ts
+++ b/src/__tests__/getMessageAuthorFactory.test.ts
@@ -1,14 +1,17 @@
 import * as github from '@actions/github'
 import {afterEach, beforeEach, describe, expect, it, jest} from '@jest/globals'
 import {
-  getMessageAuthor,
+  GetMessageAuthor,
+  getMessageAuthorFactory,
   GH_MERGE_QUEUE_BOT_USERNAME
-} from '../getMessageAuthor'
+} from '../getMessageAuthorFactory'
 import {OctokitClient} from '../github/types'
 import {SlackClient} from '../slack/SlackClient'
 import {Member, MessageAuthor} from '../slack/types'
 
-describe('getMessageAuthor', () => {
+describe('getMessageAuthorFactory', () => {
+  let getMessageAuthor: GetMessageAuthor
+
   let octokit: OctokitClient
   let slack: SlackClient
   let messageAuthor: MessageAuthor | null
@@ -55,6 +58,8 @@ describe('getMessageAuthor', () => {
     slack = {
       getRealUsers: jest.fn()
     } as unknown as SlackClient
+
+    getMessageAuthor = getMessageAuthorFactory(octokit, slack)
   })
 
   afterEach(() => {
@@ -64,7 +69,7 @@ describe('getMessageAuthor', () => {
 
   describe('missing Slack OAuth scope', () => {
     beforeEach(async () => {
-      messageAuthor = await getMessageAuthor(octokit, slack)
+      messageAuthor = await getMessageAuthor({withSlackUserId: true})
     })
 
     it('should fetch Slack users', () => {
@@ -72,6 +77,23 @@ describe('getMessageAuthor', () => {
     })
 
     it('should fallback to GitHub username', () => {
+      expect(messageAuthor).toStrictEqual({
+        username: 'namoscato',
+        icon_url: 'github.com/namoscato'
+      })
+    })
+  })
+
+  describe('without Slack user ID', () => {
+    beforeEach(async () => {
+      messageAuthor = await getMessageAuthor({withSlackUserId: false})
+    })
+
+    it('should not fetch Slack users', () => {
+      expect(slack.getRealUsers).not.toHaveBeenCalled()
+    })
+
+    it('should return GitHub username', () => {
       expect(messageAuthor).toStrictEqual({
         username: 'namoscato',
         icon_url: 'github.com/namoscato'
@@ -103,7 +125,7 @@ describe('getMessageAuthor', () => {
 
     describe('with GitHub context', () => {
       beforeEach(async () => {
-        messageAuthor = await getMessageAuthor(octokit, slack)
+        messageAuthor = await getMessageAuthor({withSlackUserId: true})
       })
 
       it('should fallback to GitHub username', () => {
@@ -115,7 +137,7 @@ describe('getMessageAuthor', () => {
       beforeEach(async () => {
         github.context.payload = {}
 
-        messageAuthor = await getMessageAuthor(octokit, slack)
+        messageAuthor = await getMessageAuthor({withSlackUserId: true})
       })
 
       it('should return null', () => {
@@ -147,7 +169,7 @@ describe('getMessageAuthor', () => {
         ])
       )
 
-      messageAuthor = await getMessageAuthor(octokit, slack)
+      messageAuthor = await getMessageAuthor({withSlackUserId: true})
     })
 
     it('should fallback to GitHub username', () => {
@@ -178,7 +200,7 @@ describe('getMessageAuthor', () => {
         ])
       )
 
-      messageAuthor = await getMessageAuthor(octokit, slack)
+      messageAuthor = await getMessageAuthor({withSlackUserId: true})
     })
 
     it('should return Slack user', () => {
@@ -224,7 +246,7 @@ describe('getMessageAuthor', () => {
           ])
         )
 
-        messageAuthor = await getMessageAuthor(octokit, slack)
+        messageAuthor = await getMessageAuthor({withSlackUserId: true})
       })
 
       it('fetches the GH user that merged the PR', () => {
@@ -258,7 +280,7 @@ describe('getMessageAuthor', () => {
       })
 
       it('does not fallback on the merge queue user', async () => {
-        expect(await getMessageAuthor(octokit, slack)).toStrictEqual({
+        expect(await getMessageAuthor({withSlackUserId: true})).toStrictEqual({
           username: 'mdavis',
           icon_url: 'github.com/mdavis'
         })
@@ -271,9 +293,9 @@ describe('getMessageAuthor', () => {
       })
 
       it('falls back on merge queue user', async () => {
-        expect((await getMessageAuthor(octokit, slack))?.username).toBe(
-          GH_MERGE_QUEUE_BOT_USERNAME
-        )
+        expect(
+          (await getMessageAuthor({withSlackUserId: true}))?.username
+        ).toBe(GH_MERGE_QUEUE_BOT_USERNAME)
       })
     })
 
@@ -286,7 +308,7 @@ describe('getMessageAuthor', () => {
       })
 
       it('does not fallback on the merge queue user', async () => {
-        expect(await getMessageAuthor(octokit, slack)).toStrictEqual({
+        expect(await getMessageAuthor({withSlackUserId: true})).toStrictEqual({
           username: 'mdavis',
           icon_url: 'github.com/mdavis'
         })
@@ -303,9 +325,9 @@ describe('getMessageAuthor', () => {
       })
 
       it('falls back on merge queue user', async () => {
-        expect((await getMessageAuthor(octokit, slack))?.username).toBe(
-          GH_MERGE_QUEUE_BOT_USERNAME
-        )
+        expect(
+          (await getMessageAuthor({withSlackUserId: true}))?.username
+        ).toBe(GH_MERGE_QUEUE_BOT_USERNAME)
       })
     })
   })

--- a/src/__tests__/postMessage.test.ts
+++ b/src/__tests__/postMessage.test.ts
@@ -1,10 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as github from '@actions/github'
 import {afterAll, beforeEach, describe, expect, it, jest} from '@jest/globals'
+import {GetMessageAuthor} from '../getMessageAuthorFactory'
 import {EVENT_NAME_IMAGE_MAP} from '../github/getContextBlock'
-import {OctokitClient} from '../github/types'
+import type {OctokitClient} from '../github/types'
 import {postMessage} from '../postMessage'
-import {SlackClient} from '../slack/SlackClient'
+import type {SlackClient} from '../slack/SlackClient'
 
 describe('postMessage', () => {
   let octokit: OctokitClient
@@ -65,9 +66,11 @@ describe('postMessage', () => {
       ts = await postMessage({
         octokit,
         slack,
-        author: {
-          username: 'namoscato',
-          icon_url: 'github.com/namoscato'
+        async getMessageAuthor() {
+          return Promise.resolve({
+            username: 'namoscato',
+            icon_url: 'github.com/namoscato'
+          })
         }
       })
     })
@@ -121,7 +124,11 @@ describe('postMessage', () => {
         }
       }
 
-      ts = await postMessage({octokit, slack, author: null})
+      ts = await postMessage({
+        octokit,
+        slack,
+        getMessageAuthor: getNullMessageAuthor
+      })
     })
 
     it('should post slack message', () => {
@@ -174,11 +181,7 @@ describe('postMessage', () => {
       ts = await postMessage({
         octokit,
         slack,
-        author: {
-          slack_user_id: 'U123',
-          username: 'Nick',
-          icon_url: 'slack.com/nick'
-        }
+        getMessageAuthor
       })
     })
 
@@ -238,7 +241,11 @@ describe('postMessage', () => {
         }
       })) as any
 
-      ts = await postMessage({octokit, slack, author: null})
+      ts = await postMessage({
+        octokit,
+        slack,
+        getMessageAuthor: getNullMessageAuthor
+      })
     })
 
     it('should fetch commit', () => {
@@ -320,10 +327,7 @@ describe('postMessage', () => {
         ts = await postMessage({
           octokit,
           slack,
-          author: {
-            username: 'namoscato',
-            icon_url: 'github.com/namoscato'
-          }
+          getMessageAuthor
         })
       })
 
@@ -389,7 +393,11 @@ describe('postMessage', () => {
       beforeEach(async () => {
         process.env.INPUT_STATUS = 'cancelled'
 
-        ts = await postMessage({octokit, slack, author: null})
+        ts = await postMessage({
+          octokit,
+          slack,
+          getMessageAuthor: getNullMessageAuthor
+        })
       })
 
       it('should post slack message', () => {
@@ -458,11 +466,7 @@ describe('postMessage', () => {
         ts = await postMessage({
           octokit,
           slack,
-          author: {
-            slack_user_id: 'U123',
-            username: 'Nick',
-            icon_url: 'slack.com/nick'
-          }
+          getMessageAuthor
         })
       })
 
@@ -513,7 +517,11 @@ describe('postMessage', () => {
         process.env.INPUT_STATUS = 'failure'
         process.env.INPUT_CONCLUSION = 'true'
 
-        ts = await postMessage({octokit, slack, author: null})
+        ts = await postMessage({
+          octokit,
+          slack,
+          getMessageAuthor: getNullMessageAuthor
+        })
       })
 
       it('should post slack message', () => {
@@ -565,7 +573,11 @@ describe('postMessage', () => {
 
         process.env.INPUT_STATUS = 'success'
 
-        ts = await postMessage({octokit, slack, author: null})
+        ts = await postMessage({
+          octokit,
+          slack,
+          getMessageAuthor: getNullMessageAuthor
+        })
       })
 
       it('should post slack message', () => {
@@ -599,7 +611,11 @@ describe('postMessage', () => {
 
         process.env.INPUT_STATUS = 'success'
 
-        ts = await postMessage({octokit, slack, author: null})
+        ts = await postMessage({
+          octokit,
+          slack,
+          getMessageAuthor: getNullMessageAuthor
+        })
       })
 
       it('should post slack message', () => {
@@ -635,7 +651,11 @@ describe('postMessage', () => {
       github.context.eventName = 'issues'
 
       try {
-        await postMessage({octokit, slack, author: null})
+        await postMessage({
+          octokit,
+          slack,
+          getMessageAuthor: getNullMessageAuthor
+        })
       } catch (err) {
         error = err as Error
       }
@@ -648,3 +668,24 @@ describe('postMessage', () => {
     })
   })
 })
+
+const getNullMessageAuthor: GetMessageAuthor = async () => {
+  return null
+}
+
+const getMessageAuthor: GetMessageAuthor = async (
+  {withSlackUserId} = {withSlackUserId: false}
+) => {
+  if (withSlackUserId) {
+    return {
+      slack_user_id: 'U123',
+      username: 'Nick',
+      icon_url: 'slack.com/nick'
+    }
+  }
+
+  return {
+    username: 'namoscato',
+    icon_url: 'github.com/namoscato'
+  }
+}

--- a/src/getMessageAuthorFactory.ts
+++ b/src/getMessageAuthorFactory.ts
@@ -8,9 +8,30 @@ import {MemberWithProfile, MessageAuthor} from './slack/types'
 
 export const GH_MERGE_QUEUE_BOT_USERNAME = 'github-merge-queue[bot]'
 
-export async function getMessageAuthor(
+export type GetMessageAuthor = (
+  options?: GetMessageAuthorOptions
+) => Promise<MessageAuthor | null>
+
+interface GetMessageAuthorOptions {
+  /** `false` falls back to GitHub username, skipping a conservatively rate-limited Slack API call */
+  withSlackUserId: boolean
+}
+
+export function getMessageAuthorFactory(
   octokit: OctokitClient,
   slack: SlackClient
+): GetMessageAuthor {
+  return async (
+    {withSlackUserId}: GetMessageAuthorOptions = {withSlackUserId: false}
+  ): Promise<MessageAuthor | null> => {
+    return getMessageAuthor(octokit, slack, withSlackUserId)
+  }
+}
+
+async function getMessageAuthor(
+  octokit: OctokitClient,
+  slack: SlackClient,
+  withSlackUserId: boolean
 ): Promise<MessageAuthor | null> {
   startGroup('Getting message author')
 
@@ -18,10 +39,18 @@ export async function getMessageAuthor(
 
   if (!githubSender) {
     warning('Unexpected GitHub sender payload.')
+    endGroup()
     return null
   }
 
   try {
+    if (!withSlackUserId) {
+      return {
+        username: githubSender.login,
+        icon_url: githubSender.avatar_url
+      }
+    }
+
     info('Fetching Slack users')
     const slackUsers = await slack.getRealUsers()
 

--- a/src/github/getStageMessage.ts
+++ b/src/github/getStageMessage.ts
@@ -1,7 +1,7 @@
 import {context} from '@actions/github'
 import {type Duration, intervalToDuration} from 'date-fns'
+import type {GetMessageAuthor} from '../getMessageAuthorFactory'
 import {bold} from '../slack/mrkdwn'
-import {MessageAuthor} from '../slack/types'
 import {getContextBlock} from './getContextBlock'
 import {createMessage, emojiFromStatus} from './message'
 import {
@@ -17,7 +17,7 @@ interface Dependencies {
   octokit: OctokitClient
   status: string
   now: Date
-  author: MessageAuthor | null
+  getMessageAuthor: GetMessageAuthor
 }
 
 /**
@@ -27,12 +27,13 @@ export async function getStageMessage({
   octokit,
   status,
   now,
-  author
+  getMessageAuthor
 }: Dependencies): Promise<StageMessage> {
   const text = getText(status)
 
   const duration = await computeDuration(octokit, now)
   const contextBlock = getContextBlock(duration)
+  const author = await getMessageAuthor()
 
   return {
     ...createMessage({text, contextBlock, author}),

--- a/src/github/getSummaryMessage.ts
+++ b/src/github/getSummaryMessage.ts
@@ -1,5 +1,6 @@
 import * as github from '@actions/github'
 import {intervalToDuration} from 'date-fns'
+import type {GetMessageAuthor} from '../getMessageAuthorFactory'
 import {bold, emoji, link} from '../slack/mrkdwn'
 import {Link, MessageAuthor} from '../slack/types'
 import {dateFromTs} from '../slack/utils/dateFromTs'
@@ -25,7 +26,7 @@ interface Options {
 interface Dependencies {
   octokit: OctokitClient
   options?: Options
-  author: MessageAuthor | null
+  getMessageAuthor: GetMessageAuthor
 }
 
 /**
@@ -34,8 +35,9 @@ interface Dependencies {
 export async function getSummaryMessage({
   octokit,
   options,
-  author
+  getMessageAuthor
 }: Dependencies): Promise<Message> {
+  const author = await getMessageAuthor({withSlackUserId: true})
   const text = await getText(octokit, options?.status ?? null, author)
 
   const duration = options

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import {error, getInput, isDebug, setFailed, setOutput} from '@actions/core'
 import {getOctokit} from '@actions/github'
-import {getMessageAuthor} from './getMessageAuthor'
+import {getMessageAuthorFactory} from './getMessageAuthorFactory'
 import {OctokitClient} from './github/types'
 import {EnvironmentVariable, getEnv, getRequiredEnv} from './input'
 import {postMessage} from './postMessage'
@@ -13,8 +13,8 @@ async function run(): Promise<void> {
     const octokit = createOctokitClient()
     const slack = createSlackClient()
 
-    const author = await getMessageAuthor(octokit, slack)
-    const ts = await postMessage({octokit, slack, author})
+    const getMessageAuthor = getMessageAuthorFactory(octokit, slack)
+    const ts = await postMessage({octokit, slack, getMessageAuthor})
 
     if (ts) {
       setOutput('ts', ts)

--- a/src/postMessage.ts
+++ b/src/postMessage.ts
@@ -1,14 +1,14 @@
 import {getInput, info} from '@actions/core'
+import type {GetMessageAuthor} from './getMessageAuthorFactory'
 import {getStageMessage} from './github/getStageMessage'
 import {getSummaryMessage} from './github/getSummaryMessage'
 import {OctokitClient, isSuccessfulStatus} from './github/types'
-import {SlackClient} from './slack/SlackClient'
-import {MessageAuthor} from './slack/types'
+import type {SlackClient} from './slack/SlackClient'
 
 interface Dependencies {
   octokit: OctokitClient
   slack: SlackClient
-  author: MessageAuthor | null
+  getMessageAuthor: GetMessageAuthor
 }
 
 /**
@@ -21,13 +21,13 @@ interface Dependencies {
 export async function postMessage({
   octokit,
   slack,
-  author
+  getMessageAuthor
 }: Dependencies): Promise<string | null> {
   const threadTs = getInput('thread_ts')
 
   if (!threadTs) {
     info('Posting summary message')
-    const message = await getSummaryMessage({octokit, author})
+    const message = await getSummaryMessage({octokit, getMessageAuthor})
 
     return slack.postMessage(message)
   }
@@ -38,7 +38,7 @@ export async function postMessage({
     octokit,
     status,
     now,
-    author
+    getMessageAuthor
   })
 
   info(`Posting stage message in thread: ${threadTs}`)
@@ -56,7 +56,7 @@ export async function postMessage({
     const summaryMessage = await getSummaryMessage({
       octokit,
       options: {status, threadTs, now},
-      author
+      getMessageAuthor
     })
 
     await slack.updateMessage({

--- a/src/slack/SlackClient.ts
+++ b/src/slack/SlackClient.ts
@@ -25,7 +25,8 @@ export class SlackClient {
     this.errorReaction = errorReaction
 
     this.web = new WebClient(token, {
-      logLevel: isDebug() ? LogLevel.DEBUG : LogLevel.INFO
+      logLevel: isDebug() ? LogLevel.DEBUG : LogLevel.INFO,
+      rejectRateLimitedCalls: true
     })
     this.logRateLimits()
   }
@@ -115,10 +116,8 @@ export class SlackClient {
    * @see https://slack.dev/node-slack-sdk/web-api#rate-limits
    */
   private logRateLimits(): void {
-    this.web.on(WebClientEvent.RATE_LIMITED, numSeconds => {
-      warning(
-        `Slack API call failed due to rate limiting. Retrying in ${numSeconds} seconds.`
-      )
+    this.web.on(WebClientEvent.RATE_LIMITED, () => {
+      warning('Slack API call failed due to rate limiting.')
     })
   }
 }


### PR DESCRIPTION
Resolves https://github.com/Fieldguide/action-slack-deploy-pipeline/issues/151

## Summary

* Move `getMessageAuthor` → `getMessageAuthorFactory`, enabling runtime-based `withSlackUserId` option / deferred API calls
* Disable Slack user ID matching in `getStageMessage` context to mitigate `users.list` rate limiting
* Opt out of [Slack's rate limit retry algorithm](https://docs.slack.dev/tools/node-slack-sdk/web-api#rate-limits) via `rejectRateLimitedCalls`

## Testing

I have E2E tests hitting up a personal Slack workspace, and the threaded message references a GitHub username (previously mapped to Slack "Nick" name):

<img width="683" height="288" alt="Screenshot 2025-08-19 at 9 25 11 PM" src="https://github.com/user-attachments/assets/da047d27-3829-4b5e-9ac5-24acd0ef58ba" />

