### PR TITLE
Remove obsolete @types/js-yaml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,6 @@ updates:
     directory: '/'
     schedule:
       interval: 'monthly'
-    reviewers:
-      - 'Fieldguide/ci'
 
   - package-ecosystem: npm
     directory: /

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "@jest/globals": "^30.2.0",
     "@octokit/types": "^15.0.0",
     "@octokit/webhooks-types": "^7.6.1",
-    "@types/js-yaml": "^4.0.9",
     "@types/node": "^24.0.0",
     "@typescript-eslint/parser": "^8.58.2",
     "@vercel/ncc": "^0.38.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,9 +36,6 @@ importers:
       '@octokit/webhooks-types':
         specifier: ^7.6.1
         version: 7.6.1
-      '@types/js-yaml':
-        specifier: ^4.0.9
-        version: 4.0.9
       '@types/node':
         specifier: ^24.0.0
         version: 24.12.2
@@ -544,9 +541,6 @@ packages:
 
   '@types/istanbul-reports@3.0.4':
     resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
-
-  '@types/js-yaml@4.0.9':
-    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -3198,8 +3192,6 @@ snapshots:
   '@types/istanbul-reports@3.0.4':
     dependencies:
       '@types/istanbul-lib-report': 3.0.3
-
-  '@types/js-yaml@4.0.9': {}
 
   '@types/json-schema@7.0.15': {}
 


### PR DESCRIPTION
Follow-up to #189, which bumped `js-yaml` to `^5.2.2` but left its types package behind.

## `@types/js-yaml` is obsolete, not stale

js-yaml 5.0.0 was [rewritten in TypeScript](https://github.com/nodeca/js-yaml/blob/master/CHANGELOG.md) and ships its own definitions:

```json
"types": "./dist/js-yaml.d.ts",
"exports": { ".": { "types": "./dist/js-yaml.d.ts", ... } }
```

There is no `@types/js-yaml@5` — DefinitelyTyped stops at `4.0.9`, so there was nothing to bump it _to_. The stub was describing a v4 API that v5 removed (`Type`, `DEFAULT_SCHEMA`, `onWarning`), so it's deleted rather than upgraded.

## Dependabot `reviewers`

GitHub [removed the `reviewers` option](https://github.blog/changelog/2025-05-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/) on 2025-05-20 because it conflicted with code owners. It has been silently ignored since, so it's dropped from the `github-actions` ecosystem.

Note this leaves no reviewer automation — the documented replacement is a `CODEOWNERS` file, which this repo doesn't have. Deliberately left out of this PR since it changes who's required to approve.

## v5 changelog review

Only `yaml.load()` is used (`src/utils/getMessageAuthorFactory.ts:219`), which keeps the blast radius small. No code changes needed, but two notes:

1. **`load()` now throws on empty input** instead of returning `undefined`. The call site already guards falsy input, and whitespace-only input previously failed `isGitHubUserMapping` → same `catch` → same `warning()` + Slack-API fallback. Equivalent behavior; only the warning text differs.
2. **`load` now defaults to `CORE_SCHEMA` without `!!merge`** (v4's `DEFAULT_SCHEMA` included YAML 1.1 tags and merge keys). Since `SLACK_DEPLOY_GITHUB_USERS` is user-supplied YAML in a published action, a mapping using `<<:` merge keys or `!!` tags would now silently fall back to name matching. The README example is plain scalars, so the docs stay accurate — flagging as a possible support question.

Not applicable: the removed loader options (`onWarning`, `legacy`, `listener`) and all dumper changes, since `dump` is never called. `^5.2.2` also picks up both v5 security fixes (exponential flow-sequence parsing, quadratic `!!omap`).

## Verification

- `pnpm lint` — 0 errors; types resolve from the bundled `.d.ts`
- `pnpm test:ci` — 63/63 pass
- `pnpm format:check` — clean
- `pnpm bundle` under Node 24 — `dist/` is **byte-identical**, so `check-dist` stays green and #189's bundle was correct. No `dist/` changes are included, as this is a types-only dependency removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
