### PR TITLE
Deep link stage messages to their workflow job

### DIFF
--- a/dist/notifySlack/index.js
+++ b/dist/notifySlack/index.js
@@ -66442,8 +66442,7 @@ function getImage() {
 /**
  * Return a link to the current workflow name.
  *
- * When `url` is provided (e.g. a specific job's `html_url` for stage messages),
- * link directly to it; otherwise fall back to the run's checks page.
+ * @param url optional deep link; otherwise fall back to the run's checks page
  */
 function getWorkflow(url) {
     const text = github_1.context.workflow;

--- a/dist/notifySlack/index.js
+++ b/dist/notifySlack/index.js
@@ -66411,8 +66411,8 @@ exports.EVENT_NAME_IMAGE_MAP = {
     release: 'https://user-images.githubusercontent.com/847532/265212273-b8c1036a-26b0-4196-bb11-0cbcb85d57c0.png',
     workflow_dispatch: 'https://user-images.githubusercontent.com/847532/197601879-3bc8bf73-87c0-4216-8de7-c55d34993ef1.png'
 };
-function getContextBlock(duration) {
-    const textParts = [(0, mrkdwn_1.link)(getWorkflow()), getRef()];
+function getContextBlock({ duration, workflowUrl }) {
+    const textParts = [(0, mrkdwn_1.link)(getWorkflow(workflowUrl)), getRef()];
     if (duration) {
         textParts.push((0, date_fns_1.formatDuration)(duration) || '0 seconds');
     }
@@ -66441,9 +66441,15 @@ function getImage() {
 }
 /**
  * Return a link to the current workflow name.
+ *
+ * When `url` is provided (e.g. a specific job's `html_url` for stage messages),
+ * link directly to it; otherwise fall back to the run's checks page.
  */
-function getWorkflow() {
+function getWorkflow(url) {
     const text = github_1.context.workflow;
+    if (url) {
+        return { text, url };
+    }
     if ((0, webhook_1.isPullRequestEvent)(github_1.context)) {
         return {
             text,
@@ -66497,8 +66503,12 @@ const types_1 = __nccwpck_require__(5941);
  */
 async function getStageMessage({ jobs, status, now, getMessageAuthor }) {
     const text = getText(status);
-    const duration = computeDuration(jobs, now);
-    const contextBlock = (0, getContextBlock_1.getContextBlock)(duration);
+    const currentJob = jobs.find(({ name }) => name === github_1.context.job);
+    const duration = computeDuration(currentJob, now);
+    const contextBlock = (0, getContextBlock_1.getContextBlock)({
+        duration,
+        workflowUrl: currentJob?.html_url ?? undefined
+    });
     const author = await getMessageAuthor();
     return {
         ...(0, message_1.createMessage)({ text, contextBlock, author }),
@@ -66529,8 +66539,7 @@ function verbFromStatus(status) {
             throw new Error(`Unexpected status ${status}`);
     }
 }
-function computeDuration(jobs, now) {
-    const currentJob = jobs.find(({ name }) => name === github_1.context.job);
+function computeDuration(currentJob, now) {
     const slackRegex = /[^A-Za-z]slack[^A-Za-z]/i;
     const lastCompletedSlackStep = currentJob?.steps
         ?.filter(types_1.isCompletedJobStep)
@@ -66608,7 +66617,7 @@ async function getSummaryMessage({ octokit, options, getMessageAuthor }) {
             end: options.now
         })
         : undefined;
-    const contextBlock = (0, getContextBlock_1.getContextBlock)(duration);
+    const contextBlock = (0, getContextBlock_1.getContextBlock)({ duration });
     return (0, message_1.createMessage)({ text, contextBlock, author });
 }
 async function getText(octokit, status, author) {

--- a/src/github/getContextBlock.ts
+++ b/src/github/getContextBlock.ts
@@ -67,8 +67,7 @@ function getImage(): Image {
 /**
  * Return a link to the current workflow name.
  *
- * When `url` is provided (e.g. a specific job's `html_url` for stage messages),
- * link directly to it; otherwise fall back to the run's checks page.
+ * @param url optional deep link; otherwise fall back to the run's checks page
  */
 function getWorkflow(url: string | undefined): Link {
   const text = context.workflow

--- a/src/github/getContextBlock.ts
+++ b/src/github/getContextBlock.ts
@@ -23,8 +23,16 @@ export const EVENT_NAME_IMAGE_MAP: Record<SupportedEventName, string> = {
     'https://user-images.githubusercontent.com/847532/197601879-3bc8bf73-87c0-4216-8de7-c55d34993ef1.png'
 } as const
 
-export function getContextBlock(duration?: Duration): ContextBlock {
-  const textParts = [link(getWorkflow()), getRef()]
+interface Options {
+  duration: Duration | undefined
+  workflowUrl?: string
+}
+
+export function getContextBlock({
+  duration,
+  workflowUrl
+}: Options): ContextBlock {
+  const textParts = [link(getWorkflow(workflowUrl)), getRef()]
 
   if (duration) {
     textParts.push(formatDuration(duration) || '0 seconds')
@@ -58,9 +66,16 @@ function getImage(): Image {
 
 /**
  * Return a link to the current workflow name.
+ *
+ * When `url` is provided (e.g. a specific job's `html_url` for stage messages),
+ * link directly to it; otherwise fall back to the run's checks page.
  */
-function getWorkflow(): Link {
+function getWorkflow(url: string | undefined): Link {
   const text = context.workflow
+
+  if (url) {
+    return {text, url}
+  }
 
   if (isPullRequestEvent(context)) {
     return {

--- a/src/github/getStageMessage.ts
+++ b/src/github/getStageMessage.ts
@@ -31,8 +31,12 @@ export async function getStageMessage({
 }: Dependencies): Promise<StageMessage> {
   const text = getText(status)
 
-  const duration = computeDuration(jobs, now)
-  const contextBlock = getContextBlock(duration)
+  const currentJob = jobs.find(({name}) => name === context.job)
+  const duration = computeDuration(currentJob, now)
+  const contextBlock = getContextBlock({
+    duration,
+    workflowUrl: currentJob?.html_url ?? undefined
+  })
   const author = await getMessageAuthor()
 
   return {
@@ -69,9 +73,10 @@ function verbFromStatus(status: string): string {
   }
 }
 
-function computeDuration(jobs: WorkflowJob[], now: Date): Duration | undefined {
-  const currentJob = jobs.find(({name}) => name === context.job)
-
+function computeDuration(
+  currentJob: WorkflowJob | undefined,
+  now: Date
+): Duration | undefined {
   const slackRegex = /[^A-Za-z]slack[^A-Za-z]/i
   const lastCompletedSlackStep = currentJob?.steps
     ?.filter(isCompletedJobStep)

--- a/src/github/getSummaryMessage.ts
+++ b/src/github/getSummaryMessage.ts
@@ -1,9 +1,9 @@
 import * as github from '@actions/github'
 import {intervalToDuration} from 'date-fns'
-import type {GetMessageAuthor} from '../utils/getMessageAuthorFactory'
 import {bold, emoji, link} from '../slack/mrkdwn'
 import {Link, MessageAuthor} from '../slack/types'
 import {dateFromTs} from '../slack/utils/dateFromTs'
+import type {GetMessageAuthor} from '../utils/getMessageAuthorFactory'
 import {getContextBlock} from './getContextBlock'
 import {createMessage, emojiFromStatus} from './message'
 import {JobStatus, Message, OctokitClient, Text} from './types'
@@ -47,7 +47,7 @@ export async function getSummaryMessage({
       })
     : undefined
 
-  const contextBlock = getContextBlock(duration)
+  const contextBlock = getContextBlock({duration})
 
   return createMessage({text, contextBlock, author})
 }

--- a/src/utils/__tests__/postMessage.test.ts
+++ b/src/utils/__tests__/postMessage.test.ts
@@ -392,6 +392,8 @@ describe('postMessage', () => {
           status: 'in_progress',
           conclusion: null,
           started_at: '2022-09-10T00:00:06.000Z',
+          html_url:
+            'https://github.com/namoscato/action-testing/actions/runs/123/job/456',
           steps: [
             {
               name: 'Run namoscato/action-slack-deploy-pipeline',
@@ -450,7 +452,7 @@ describe('postMessage', () => {
                 },
                 {
                   type: 'mrkdwn',
-                  text: '<https://github.com/namoscato/action-testing/commit/05b16c3beb3a07dceaf6cf964d0be9eccbc026e8/checks|Deploy App>  ∙  05b16c3  ∙  9 seconds' // from job.started_at = 00:06
+                  text: '<https://github.com/namoscato/action-testing/actions/runs/123/job/456|Deploy App>  ∙  05b16c3  ∙  9 seconds' // from job.started_at = 00:06
                 }
               ]
             }
@@ -793,6 +795,8 @@ describe('postMessage', () => {
             status: 'in_progress',
             conclusion: null,
             started_at: '2022-09-10T00:00:04.000Z',
+            html_url:
+              'https://github.com/namoscato/action-testing/actions/runs/123/job/456',
             steps: [
               {
                 name: 'Post to Slack',
@@ -835,7 +839,7 @@ describe('postMessage', () => {
                     image_url: EVENT_NAME_IMAGE_MAP['push']
                   },
                   {
-                    text: '<https://github.com/namoscato/action-testing/commit/05b16c3beb3a07dceaf6cf964d0be9eccbc026e8/checks|Deploy App>  ∙  05b16c3  ∙  10 seconds', // from step.completed_at = 00:05
+                    text: '<https://github.com/namoscato/action-testing/actions/runs/123/job/456|Deploy App>  ∙  05b16c3  ∙  10 seconds', // from step.completed_at = 00:05
                     type: 'mrkdwn'
                   }
                 ]
@@ -874,7 +878,7 @@ describe('postMessage', () => {
                   },
                   {
                     type: 'mrkdwn',
-                    text: '<https://github.com/namoscato/action-testing/commit/05b16c3beb3a07dceaf6cf964d0be9eccbc026e8/checks|Deploy App>  ∙  05b16c3  ∙  0 seconds'
+                    text: '<https://github.com/namoscato/action-testing/actions/runs/123/job/456|Deploy App>  ∙  05b16c3  ∙  0 seconds'
                   }
                 ]
               }


### PR DESCRIPTION
Stage message context blocks link to the run's checks page rather than the job that ran. This points the workflow link at the specific job's `html_url`, so a failed stage surfaces the exact job.

`getContextBlock` now takes a single options object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)