### PR TITLE
Link context block to the workflow run

### DIFF
--- a/dist/notifySlack/index.js
+++ b/dist/notifySlack/index.js
@@ -66442,30 +66442,21 @@ function getImage() {
 /**
  * Return a link to the current workflow name.
  *
- * @param url optional deep link; otherwise fall back to the run's checks page
+ * @param url optional deep link (e.g. a specific job); otherwise fall back to
+ * the workflow run
  */
 function getWorkflow(url) {
-    const text = github_1.context.workflow;
-    if (url) {
-        return { text, url };
-    }
-    if ((0, webhook_1.isPullRequestEvent)(github_1.context)) {
-        return {
-            text,
-            url: `${github_1.context.payload.pull_request.html_url}/checks`
-        };
-    }
-    if ((0, webhook_1.isReleaseEvent)(github_1.context)) {
-        const { owner, repo } = github_1.context.repo;
-        return {
-            text,
-            url: `https://github.com/${owner}/${repo}/actions`
-        };
-    }
     return {
-        text,
-        url: `${getCommitUrl()}/checks`
+        text: github_1.context.workflow,
+        url: url ?? getRunUrl()
     };
+}
+/**
+ * Return a link to the current workflow run.
+ */
+function getRunUrl() {
+    const { owner, repo } = github_1.context.repo;
+    return `https://github.com/${owner}/${repo}/actions/runs/${github_1.context.runId}`;
 }
 /**
  * Return the pull request head branch or short commit hash.
@@ -66475,10 +66466,6 @@ function getRef() {
         return github_1.context.payload.pull_request.head.ref;
     }
     return github_1.context.sha.substring(0, 7);
-}
-function getCommitUrl() {
-    const { owner, repo } = github_1.context.repo;
-    return `https://github.com/${owner}/${repo}/commit/${github_1.context.sha}`;
 }
 
 

--- a/src/github/getContextBlock.ts
+++ b/src/github/getContextBlock.ts
@@ -7,7 +7,6 @@ import {
   SupportedEventName,
   UnsupportedEventError,
   isPullRequestEvent,
-  isReleaseEvent,
   isSupportedEvent
 } from './webhook'
 
@@ -67,35 +66,23 @@ function getImage(): Image {
 /**
  * Return a link to the current workflow name.
  *
- * @param url optional deep link; otherwise fall back to the run's checks page
+ * @param url optional deep link (e.g. a specific job); otherwise fall back to
+ * the workflow run
  */
 function getWorkflow(url: string | undefined): Link {
-  const text = context.workflow
-
-  if (url) {
-    return {text, url}
-  }
-
-  if (isPullRequestEvent(context)) {
-    return {
-      text,
-      url: `${context.payload.pull_request.html_url}/checks`
-    }
-  }
-
-  if (isReleaseEvent(context)) {
-    const {owner, repo} = context.repo
-
-    return {
-      text,
-      url: `https://github.com/${owner}/${repo}/actions`
-    }
-  }
-
   return {
-    text,
-    url: `${getCommitUrl()}/checks`
+    text: context.workflow,
+    url: url ?? getRunUrl()
   }
+}
+
+/**
+ * Return a link to the current workflow run.
+ */
+function getRunUrl(): string {
+  const {owner, repo} = context.repo
+
+  return `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`
 }
 
 /**
@@ -107,10 +94,4 @@ function getRef(): string {
   }
 
   return context.sha.substring(0, 7)
-}
-
-function getCommitUrl(): string {
-  const {owner, repo} = context.repo
-
-  return `https://github.com/${owner}/${repo}/commit/${context.sha}`
 }

--- a/src/utils/__tests__/postMessage.test.ts
+++ b/src/utils/__tests__/postMessage.test.ts
@@ -116,7 +116,7 @@ describe('postMessage', () => {
               },
               {
                 type: 'mrkdwn',
-                text: '<github.com/PR-1/checks|Deploy App>  ∙  my-pr'
+                text: '<https://github.com/namoscato/action-testing/actions/runs/123|Deploy App>  ∙  my-pr'
               }
             ]
           }
@@ -235,7 +235,7 @@ describe('postMessage', () => {
                 },
                 {
                   type: 'mrkdwn',
-                  text: '<https://github.com/namoscato/action-testing/actions|Deploy App>  ∙  05b16c3'
+                  text: '<https://github.com/namoscato/action-testing/actions/runs/123|Deploy App>  ∙  05b16c3'
                 }
               ]
             }
@@ -300,7 +300,7 @@ describe('postMessage', () => {
               },
               {
                 type: 'mrkdwn',
-                text: '<https://github.com/namoscato/action-testing/commit/05b16c3beb3a07dceaf6cf964d0be9eccbc026e8/checks|Deploy App>  ∙  05b16c3'
+                text: '<https://github.com/namoscato/action-testing/actions/runs/123|Deploy App>  ∙  05b16c3'
               }
             ]
           }
@@ -527,7 +527,7 @@ describe('postMessage', () => {
                   },
                   {
                     type: 'mrkdwn',
-                    text: '<https://github.com/namoscato/action-testing/commit/05b16c3beb3a07dceaf6cf964d0be9eccbc026e8/checks|Deploy App>  ∙  05b16c3  ∙  15 seconds'
+                    text: '<https://github.com/namoscato/action-testing/actions/runs/123|Deploy App>  ∙  05b16c3  ∙  15 seconds'
                   }
                 ]
               }
@@ -587,7 +587,7 @@ describe('postMessage', () => {
                   },
                   {
                     type: 'mrkdwn',
-                    text: '<https://github.com/namoscato/action-testing/commit/05b16c3beb3a07dceaf6cf964d0be9eccbc026e8/checks|Deploy App>  ∙  05b16c3  ∙  15 seconds'
+                    text: '<https://github.com/namoscato/action-testing/actions/runs/123|Deploy App>  ∙  05b16c3  ∙  15 seconds'
                   }
                 ]
               }


### PR DESCRIPTION
Follow-up to #218. The context block workflow link now defaults to the run itself (`actions/runs/<id>`) rather than the event's checks page, so summary messages link to the run. It's derivable from `context` alone — no job lookup needed. Stage messages still deep link to their specific job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)